### PR TITLE
fix: update Jira subtask fetching to use dynamic authentication headers

### DIFF
--- a/frontend/public/js/card.js
+++ b/frontend/public/js/card.js
@@ -1149,12 +1149,10 @@ async function handleSearchSubtasks(parentKey) {
       console.warn('Não foi possível buscar o summary do card pai:', parentError);
     }
     
-    // Agora buscar as subtasks
+    // Agora buscar as subtasks (credenciais Jira via headers do navegador)
     const response = await fetch(window.ApiConfig.buildUrl('/jira/subtasks'), {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
+      headers: { ...JiraAuth.getHeaders() },
       body: JSON.stringify({
         parent_key: parentKey,
         max_results: 100


### PR DESCRIPTION
- Modified the fetch request for subtasks to utilize dynamic authentication headers from JiraAuth, enhancing security and streamlining the process.
- Removed the static 'Content-Type' header, aligning with the new authentication approach.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small frontend-only change to request headers for a single endpoint; main risk is unexpected header composition (e.g., missing `Content-Type`) affecting the `/jira/subtasks` API contract.
> 
> **Overview**
> Updates the Jira subtask lookup in `card.js` to send `JiraAuth.getHeaders()` instead of a fixed `Content-Type` header, aligning subtask requests with the app’s dynamic Jira authentication flow.
> 
> This ensures the `/jira/subtasks` call carries the same browser-provided auth headers as other Jira requests and continues to trigger the login modal on `401` responses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c0b4def07168047e0fac026920b97b444a97acf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->